### PR TITLE
Enable users to see their own details

### DIFF
--- a/users/permissions.py
+++ b/users/permissions.py
@@ -1,0 +1,20 @@
+from rest_framework import permissions
+
+
+class IsStaff(permissions.BasePermission):
+    """
+    Custom permission to allow staff to see the list of users.
+    """
+
+    def has_permission(self, request, view):
+        return request.user.is_staff
+
+
+class IsStaffOrUser(permissions.BasePermission):
+    """
+    Custom permission to allow only staff or the user themselves
+    to see a user's details.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        return request.user.is_staff or obj == request.user

--- a/users/views.py
+++ b/users/views.py
@@ -4,6 +4,7 @@ from rest_framework import permissions, viewsets
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
+from users.permissions import IsStaff, IsStaffOrUser
 from users.serializers import UserSerializer, GroupSerializer
 
 
@@ -14,7 +15,13 @@ class UserViewSet(viewsets.ModelViewSet):
     """
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    permission_classes = [permissions.IsAdminUser]
+
+    def get_permissions(self):
+        if self.action == 'retrieve':
+            self.permission_classes = [IsStaffOrUser]
+        else:
+            self.permission_classes = [IsStaff]
+        return super(self.__class__, self).get_permissions()
 
 
 class GroupViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
## Previous State
Only admin users could see or do anything to do with users.

## New State
- Users can see their own details (but not the list of users or other users' details)
- Staff can see the list of users and add/remove users